### PR TITLE
Move from WiringPI to rpio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,12 @@
       }
     },
     "bindings": {
-      "version": "1.2.1",
-      "resolved": "http://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -158,6 +161,11 @@
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "find-up": {
       "version": "3.0.0",
@@ -314,24 +322,15 @@
       "dev": true
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-wiring-pi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/node-wiring-pi/-/node-wiring-pi-0.0.4.tgz",
-      "integrity": "sha512-sFvIcR0r/UzhOwXVhPnSylwRbGLuDgkz2UXXu05vgiZdZ4ikz7/qHOW38vFCoX1Gl+fYLDknoMhNj+dnSaRwKw==",
-      "requires": {
-        "bindings": "1.2.1",
-        "nan": "^2.4.0"
-      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -567,6 +566,15 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
+    },
+    "rpio": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/rpio/-/rpio-2.2.0.tgz",
+      "integrity": "sha512-zuOHIqKKxdS7RuY6wde70r+Nx4MsrypFotsgPuCkpxYlJQlq27KinJg5VlsKcU6b1ukwxTx9zA5UtWXaZFjn5g==",
+      "requires": {
+        "bindings": "~1.5.0",
+        "nan": "^2.14.1"
+      }
     },
     "run-node": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/globalroo/blinkt-kit#readme",
   "dependencies": {
-    "node-wiring-pi": "0.0.4"
+    "rpio": "^2.2.0"
   },
   "devDependencies": {
     "husky": "^1.2.1",

--- a/src/blinkt.js
+++ b/src/blinkt.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const wpi = require("node-wiring-pi");
+const rpio = require("rpio");
 
 const DAT = 23;
 const CLK = 24;
@@ -17,9 +17,9 @@ class Blinkt {
 		this.dat = dat;
 		this.clk = clk;
 
-		wpi.setup(mode);
-		wpi.pinMode(this.dat, wpi.OUTPUT);
-		wpi.pinMode(this.clk, wpi.OUTPUT);
+		rpio.init({ mapping: mode, close_on_exit: false });
+		rpio.open(this.dat, rpio.OUTPUT, rpio.LOW);
+		rpio.open(this.clk, rpio.OUTPUT, rpio.LOW);
 
 		this.blinktPixels = Array.from(new Array(DEFAULT_PIXELS), () => [DEFAULT_RED, DEFAULT_GREEN, DEFAULT_BLUE, 0]);
 
@@ -63,6 +63,7 @@ class Blinkt {
 
 	cleanup() {
 		this.clear();
+		rpio.exit();
 		process.exit();
 	}
 
@@ -74,14 +75,14 @@ class Blinkt {
 	}
 
 	writeData(bit) {
-		wpi.digitalWrite(this.dat, bit);
-		wpi.digitalWrite(this.clk, 1);
-		wpi.digitalWrite(this.clk, 0);
+		rpio.write(this.dat, bit);
+		rpio.write(this.clk, rpio.HIGH);
+		rpio.write(this.clk, rpio.LOW);
 	}
 
 	writeByte(byte) {
 		for (let i = 0; i < DEFAULT_PIXELS; i++) {
-			const bit = (byte & (1 << (7 - i))) > 0 === true ? wpi.HIGH : wpi.LOW;
+			const bit = (byte & (1 << (7 - i))) > 0 === true ? rpio.HIGH : rpio.LOW;
 			this.writeData(bit);
 		}
 	}


### PR DESCRIPTION
I hit a number of issues getting node-wiringpi to compile correctly with NodeJS v12 on a Pi3.  Looked for a replacement that was being maintained a bit more.  rpio proved to provide a fairly close interface.

Examples all run on a pi3 with Blinkt

I asked if this was a welcome pull request in #1 